### PR TITLE
Fix TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,3 @@
-export default function detach(buf: ArrayBuffer | ArrayBufferView): void;
+declare function detach(buf: ArrayBuffer | ArrayBufferView): void;
+
+export = detach;


### PR DESCRIPTION
The correct way to type `module.exports =`, is using the TypeScript syntax `export =`. For CJS `export default` in TypeScript represents `module.exports.default`.