### PR TITLE
Remove unused import

### DIFF
--- a/benchmark.mjs
+++ b/benchmark.mjs
@@ -1,4 +1,3 @@
-import fs from 'node:fs/promises'
 import { spawn } from 'node:child_process'
 import detach from './index.js'
 


### PR DESCRIPTION
This causes `standard` to fail.